### PR TITLE
feat: add support for UniFi EV Station Lite

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ To use this integration:
   - Volume control
   - Mode switching (Web, App) with URL selection, App Selection
   - Other settings like reload, sleep, etc...
+- Support for **UniFi EV Station Lite**, including:
+  - Charging status monitoring
+  - Charging enable/disable control
+  - Max output amperage control (6-40A)
+  - Display brightness control
+  - Status light control
+  - Station mode selection (Plug & Charge, No Access, Access with UniFi Identity)
+  - Fallback security settings
+  - Display label and admin message
+  - Locating mode
+  - Device reboot
 
 ## Installation
 

--- a/custom_components/unifi_connect/api.py
+++ b/custom_components/unifi_connect/api.py
@@ -88,12 +88,14 @@ class UnifiConnectAPI:
 
         try:
             async with async_timeout.timeout(10):
+                _LOGGER.debug("Sending action to %s: %s", url, payload)
                 async with self._session.patch(url, json=payload, headers=headers, cookies=self._cookie, ssl=False) as resp:
                     if resp.status == 200:
                         _LOGGER.debug("Action %s on %s successful", action_name, device_id)
                         return True
                     else:
-                        _LOGGER.warning("Failed to perform %s on %s: %s", action_name, device_id, resp.status)
+                        response_text = await resp.text()
+                        _LOGGER.warning("Failed to perform %s on %s: %s - Response: %s", action_name, device_id, resp.status, response_text)
         except Exception as e:
             _LOGGER.exception("Error performing %s on %s: %s", action_name, device_id, e)
         return False

--- a/custom_components/unifi_connect/button.py
+++ b/custom_components/unifi_connect/button.py
@@ -16,7 +16,14 @@ async def async_setup_entry(hass, entry, async_add_entities):
     buttons = []
 
     for device in devices:
-        if device.get("type", {}).get("platform") == "UC-Display-SE-21":
+        platform = device.get("type", {}).get("platform", "")
+
+        # EV Station Lite buttons
+        if platform == "EVS-Lite":
+            buttons.append(EVStationRebootButton(hub, device))
+
+        # Display SE 21 buttons
+        elif platform == "UC-Display-SE-21":
             buttons.append(ReloadWebButton(hub, device))
 
     async_add_entities(buttons)
@@ -48,5 +55,36 @@ class ReloadWebButton(CoordinatorEntity, ButtonEntity):
             self._device_id,
             self._action_id,
             "refresh_website"
+        )
+        await self._hub.coordinator.async_request_refresh()
+
+
+class EVStationRebootButton(CoordinatorEntity, ButtonEntity):
+    """Button to reboot the EV Station."""
+
+    def __init__(self, hub: UnifiConnectHub, device: dict):
+        super().__init__(hub.coordinator)
+        self._hub = hub
+        self._device = device
+        self._device_id = device["id"]
+
+        self._attr_name = f"{device['name']} Reboot"
+        self._attr_unique_id = f"{device['id']}_reboot"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, device["id"])},
+            name=device.get("name"),
+            manufacturer="Ubiquiti",
+            model=device.get("type", {}).get("fullName", "Unknown"),
+        )
+        self._attr_icon = "mdi:restart"
+
+        self._action_id = "8d2a2b00-e9d8-403e-ae92-c6e933363561"
+
+    async def async_press(self) -> None:
+        _LOGGER.debug("Sending reboot to %s", self._attr_name)
+        await self._hub.api.perform_action(
+            self._device_id,
+            self._action_id,
+            "reboot"
         )
         await self._hub.coordinator.async_request_refresh()

--- a/custom_components/unifi_connect/const.py
+++ b/custom_components/unifi_connect/const.py
@@ -12,4 +12,4 @@ CONF_CONTROLLER_TYPE = "controller_type"
 CONTROLLER_UDMP = "Unifi Dream Machine (inc Pro)"
 CONTROLLER_OTHER = "Other Unifi Controllers"
 
-PLATFORMS = ["switch", "select", "number", "text", "button"]
+PLATFORMS = ["sensor", "switch", "select", "number", "text", "button"]

--- a/custom_components/unifi_connect/number.py
+++ b/custom_components/unifi_connect/number.py
@@ -167,7 +167,7 @@ class EVStationMaxOutputNumber(CoordinatorEntity, NumberEntity):
             self._device_id,
             self._action_id,
             "set_max_output_amp",
-            {"amperage": int(value)}
+            {"maxOutput": int(value)}
         )
         await self._hub.coordinator.async_request_refresh()
 

--- a/custom_components/unifi_connect/select.py
+++ b/custom_components/unifi_connect/select.py
@@ -161,7 +161,7 @@ class EVStationModeSelect(CoordinatorEntity, SelectEntity):
             self._device_id,
             self._action_id,
             "switch_ev_station_mode",
-            {"mode": option}
+            {"evStationMode": option}
         )
         await self._hub.coordinator.async_request_refresh()
 
@@ -201,6 +201,6 @@ class EVStationFallbackSecuritySelect(CoordinatorEntity, SelectEntity):
             self._device_id,
             self._action_id,
             "set_fallback_security",
-            {"mode": option}
+            {"fallbackSecurity": option}
         )
         await self._hub.coordinator.async_request_refresh()

--- a/custom_components/unifi_connect/sensor.py
+++ b/custom_components/unifi_connect/sensor.py
@@ -1,0 +1,161 @@
+"""Sensor platform for UniFi Connect integration."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.sensor import (
+    SensorEntity,
+    SensorDeviceClass,
+    SensorStateClass,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import UnitOfElectricCurrent
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.helpers.entity import DeviceInfo
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up UniFi Connect sensors from a config entry."""
+    hub = hass.data[DOMAIN][config_entry.entry_id]
+    devices = hub.coordinator.data
+
+    entities = []
+    for device in devices:
+        platform = device.get("type", {}).get("platform", "")
+
+        # EV Station Lite sensors
+        if platform == "EVS-Lite":
+            shadow = device.get("shadow", {})
+
+            # Charging Status sensor
+            if "chargingStatus" in shadow:
+                entities.append(EVStationChargingStatusSensor(hub, device))
+
+            # Max Current sensor
+            if "maxCurrent" in shadow:
+                entities.append(EVStationMaxCurrentSensor(hub, device))
+
+            # Derating sensor
+            if "derating" in shadow:
+                entities.append(EVStationDeratingBinarySensor(hub, device))
+
+    async_add_entities(entities)
+
+
+class EVStationChargingStatusSensor(CoordinatorEntity, SensorEntity):
+    """Sensor for EV Station charging status."""
+
+    def __init__(self, hub, device):
+        """Initialize the sensor."""
+        super().__init__(hub.coordinator)
+        self._hub = hub
+        self._device_id = device["id"]
+        self._attr_name = f"{device['name']} Charging Status"
+        self._attr_unique_id = f"{device['id']}_charging_status"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, device["id"])},
+            name=device.get("name"),
+            manufacturer="Ubiquiti",
+            model=device.get("type", {}).get("fullName"),
+            sw_version=device.get("firmwareVersion"),
+        )
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the charging status."""
+        for device in self._hub.coordinator.data:
+            if device["id"] == self._device_id:
+                return device.get("shadow", {}).get("chargingStatus")
+        return None
+
+    @property
+    def icon(self) -> str:
+        """Return the icon based on charging status."""
+        status = self.native_value
+        if status == "Charging":
+            return "mdi:ev-station"
+        elif status == "Available":
+            return "mdi:ev-plug-type1"
+        elif status == "Unavailable":
+            return "mdi:power-plug-off"
+        return "mdi:ev-station"
+
+
+class EVStationMaxCurrentSensor(CoordinatorEntity, SensorEntity):
+    """Sensor for EV Station max current."""
+
+    def __init__(self, hub, device):
+        """Initialize the sensor."""
+        super().__init__(hub.coordinator)
+        self._hub = hub
+        self._device_id = device["id"]
+        self._attr_name = f"{device['name']} Max Current"
+        self._attr_unique_id = f"{device['id']}_max_current"
+        self._attr_device_class = SensorDeviceClass.CURRENT
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+        self._attr_native_unit_of_measurement = UnitOfElectricCurrent.AMPERE
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, device["id"])},
+            name=device.get("name"),
+            manufacturer="Ubiquiti",
+            model=device.get("type", {}).get("fullName"),
+            sw_version=device.get("firmwareVersion"),
+        )
+
+    @property
+    def native_value(self) -> int | None:
+        """Return the max current."""
+        for device in self._hub.coordinator.data:
+            if device["id"] == self._device_id:
+                return device.get("shadow", {}).get("maxCurrent")
+        return None
+
+    @property
+    def icon(self) -> str:
+        """Return the icon."""
+        return "mdi:current-ac"
+
+
+class EVStationDeratingBinarySensor(CoordinatorEntity, SensorEntity):
+    """Binary sensor for EV Station derating status."""
+
+    def __init__(self, hub, device):
+        """Initialize the sensor."""
+        super().__init__(hub.coordinator)
+        self._hub = hub
+        self._device_id = device["id"]
+        self._attr_name = f"{device['name']} Derating"
+        self._attr_unique_id = f"{device['id']}_derating"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, device["id"])},
+            name=device.get("name"),
+            manufacturer="Ubiquiti",
+            model=device.get("type", {}).get("fullName"),
+            sw_version=device.get("firmwareVersion"),
+        )
+
+    @property
+    def native_value(self) -> str:
+        """Return the derating status."""
+        for device in self._hub.coordinator.data:
+            if device["id"] == self._device_id:
+                derating = device.get("shadow", {}).get("derating", False)
+                return "Active" if derating else "Inactive"
+        return "Inactive"
+
+    @property
+    def icon(self) -> str:
+        """Return the icon."""
+        derating = self.native_value == "Active"
+        return "mdi:thermometer-alert" if derating else "mdi:thermometer-check"

--- a/custom_components/unifi_connect/text.py
+++ b/custom_components/unifi_connect/text.py
@@ -106,7 +106,7 @@ class EVStationDisplayLabelText(CoordinatorEntity, TextEntity):
             self._device_id,
             self._action_id,
             "set_display_label",
-            {"label": value}
+            {"displayLabel": value}
         )
         await self._hub.coordinator.async_request_refresh()
 
@@ -145,6 +145,6 @@ class EVStationAdminMessageText(CoordinatorEntity, TextEntity):
             self._device_id,
             self._action_id,
             "set_admin_message",
-            {"message": value}
+            {"adminMessage": value}
         )
         await self._hub.coordinator.async_request_refresh()

--- a/custom_components/unifi_connect/text.py
+++ b/custom_components/unifi_connect/text.py
@@ -16,7 +16,17 @@ async def async_setup_entry(hass, entry, async_add_entities):
     texts = []
 
     for device in devices:
-        if device.get("type", {}).get("platform") == "UC-Display-SE-21":
+        platform = device.get("type", {}).get("platform", "")
+
+        # EV Station Lite text entities
+        if platform == "EVS-Lite":
+            if device.get("featureFlags", {}).get("displayLabelSupported"):
+                texts.append(EVStationDisplayLabelText(hub, device))
+            if device.get("featureFlags", {}).get("adminMessageSupported"):
+                texts.append(EVStationAdminMessageText(hub, device))
+
+        # Display SE 21 text entities
+        elif platform == "UC-Display-SE-21":
             if device.get("shadow", {}).get("currentHomePage") is not None:
                 texts.append(DisplayWebUrlText(hub, device))
 
@@ -58,5 +68,83 @@ class DisplayWebUrlText(CoordinatorEntity, TextEntity):
             self._action_id,
             "load_website",
             {"url": value}
+        )
+        await self._hub.coordinator.async_request_refresh()
+
+
+class EVStationDisplayLabelText(CoordinatorEntity, TextEntity):
+    """Display label text for EV Station."""
+
+    def __init__(self, hub: UnifiConnectHub, device: dict):
+        super().__init__(hub.coordinator)
+        self._hub = hub
+        self._device = device
+        self._device_id = device["id"]
+
+        self._attr_name = f"{device['name']} Display Label"
+        self._attr_unique_id = f"{device['id']}_display_label"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, device["id"])},
+            name=device.get("name"),
+            manufacturer="Ubiquiti",
+            model=device.get("type", {}).get("fullName", "Unknown"),
+        )
+        self._attr_native_min = 0
+        self._attr_native_max = 128
+        self._action_id = "ae1c886a-910c-4395-985b-6f93054c2e9f"
+
+    @property
+    def native_value(self):
+        for d in self._hub.coordinator.data:
+            if d["id"] == self._device_id:
+                return d.get("shadow", {}).get("displayLabel", "")
+        return ""
+
+    async def async_set_value(self, value: str) -> None:
+        _LOGGER.debug("Setting display label to %s on %s", value, self._attr_name)
+        await self._hub.api.perform_action(
+            self._device_id,
+            self._action_id,
+            "set_display_label",
+            {"label": value}
+        )
+        await self._hub.coordinator.async_request_refresh()
+
+
+class EVStationAdminMessageText(CoordinatorEntity, TextEntity):
+    """Admin message text for EV Station."""
+
+    def __init__(self, hub: UnifiConnectHub, device: dict):
+        super().__init__(hub.coordinator)
+        self._hub = hub
+        self._device = device
+        self._device_id = device["id"]
+
+        self._attr_name = f"{device['name']} Admin Message"
+        self._attr_unique_id = f"{device['id']}_admin_message"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, device["id"])},
+            name=device.get("name"),
+            manufacturer="Ubiquiti",
+            model=device.get("type", {}).get("fullName", "Unknown"),
+        )
+        self._attr_native_min = 0
+        self._attr_native_max = 256
+        self._action_id = "cddf832a-7fcd-4049-981f-281ed4a665f0"
+
+    @property
+    def native_value(self):
+        for d in self._hub.coordinator.data:
+            if d["id"] == self._device_id:
+                return d.get("shadow", {}).get("adminMessage", "")
+        return ""
+
+    async def async_set_value(self, value: str) -> None:
+        _LOGGER.debug("Setting admin message to %s on %s", value, self._attr_name)
+        await self._hub.api.perform_action(
+            self._device_id,
+            self._action_id,
+            "set_admin_message",
+            {"message": value}
         )
         await self._hub.coordinator.async_request_refresh()

--- a/custom_components/unifi_connect/text.py
+++ b/custom_components/unifi_connect/text.py
@@ -90,7 +90,7 @@ class EVStationDisplayLabelText(CoordinatorEntity, TextEntity):
             model=device.get("type", {}).get("fullName", "Unknown"),
         )
         self._attr_native_min = 0
-        self._attr_native_max = 128
+        self._attr_native_max = 15
         self._action_id = "ae1c886a-910c-4395-985b-6f93054c2e9f"
 
     @property
@@ -106,7 +106,7 @@ class EVStationDisplayLabelText(CoordinatorEntity, TextEntity):
             self._device_id,
             self._action_id,
             "set_display_label",
-            {"displayLabel": value}
+            {"enableDisplayLabel": True, "displayLabel": value}
         )
         await self._hub.coordinator.async_request_refresh()
 


### PR DESCRIPTION
Add comprehensive support for the UniFi EV Station Lite (EVS-Lite) device, including:

- Sensor entities: charging status, max current, derating status
- Switch entities: charging enable/disable, status light, locating mode
- Number entities: max output amperage (6-40A), display brightness
- Select entities: station mode (Plug & Charge, No Access, UniFi Identity), fallback security
- Text entities: display label, admin message
- Button entity: device reboot

All entities follow the same pattern as existing Display SE 21 support with proper device detection based on platform type.